### PR TITLE
UPDATE dto.template to filter self-referencing model imports

### DIFF
--- a/src/generator/templates/dto.template.ts
+++ b/src/generator/templates/dto.template.ts
@@ -25,7 +25,7 @@ export function createDtoTemplate({
   }
 
   const dtos = model.fields
-    .map((field) => (field.kind === "object" ? field.type : ""))
+    .map((field) => (field.kind === "object" && field.type !== model.name ? field.type : ""))
     .filter(Boolean);
 
   const enums = model.fields


### PR DESCRIPTION
Using a self-referencing model in schema was generating self-referencing import lines. This PR filters circular imports from the list of dto imports.

## Example behavior before the commit

```prisma
// schema.prisma

model Category {
  id    String @id @default(cuid())
  title String

  children   Category[] @relation("CategoryToCategory")
  category   Category?  @relation("CategoryToCategory", fields: [categoryId], references: [id])
  categoryId String?

  createdAt DateTime @default(now())
  updatedAt DateTime @default(now()) @updatedAt
}
```

```ts
// category.dto.ts

import { CategoryDto } from "./category.dto"; // Generator should skip this import

export class CategoryDto {
  id: string;
  title: string;
  children: CategoryDto[];
  category?: CategoryDto;
  categoryId?: string;
  createdAt: Date;
  updatedAt: Date;
}
```
